### PR TITLE
Resize MyST Markdown Images

### DIFF
--- a/index.md
+++ b/index.md
@@ -18,11 +18,23 @@ City University of New York (CUNY)<br>
 ::::{grid} 2
 
 :::{grid-item-card} Research
-[![](notes/nash_eq.png)](./notes/newpapers.md)
+```{figure} notes/nash_eq.png
+---
+width: 100%
+align: center
+---
+```
+[Link to papers](./notes/newpapers.md)
 :::
 
 :::{grid-item-card} Teaching and Code
-[![](notes/econ_teach.png)](./notes/Teaching.md)
+```{figure} notes/econ_teach.png
+---
+width: 100%
+align: center
+---
+```
+[Link to teaching](./notes/Teaching.md)
 :::
 ::::
 

--- a/notes/Teaching.md
+++ b/notes/Teaching.md
@@ -46,16 +46,34 @@ See site below.
 
 ::::{grid} 2
 :::{grid-item-card} [Econ-Teach](https://jhconning.github.io/Econ-Teach/) notebooks and apps
-[![Econ-Teach](econ_teach.png)](https://jhconning.github.io/Econ-Teach)
+```{figure} econ_teach.png
+---
+width: 100%
+align: center
+---
+```
+[Link to Econ-Teach](https://jhconning.github.io/Econ-Teach)
 :::
 
 :::{grid-item-card} [PhD Development seminar II](https://jhconning.github.io/DevII24)
-[![Harris-Todaro](HarrisTodaro_25_1.png)](https://jhconning.github.io/DevII)
+```{figure} HarrisTodaro_25_1.png
+---
+width: 100%
+align: center
+---
+```
+[Link to Seminar II](https://jhconning.github.io/DevII)
 :::
 
 :::{grid-item-card} [The Economics of Land Governance](https://github.com/jhconning/land_uct_2019)
 University of Cape Town, 2019 and 2018. Part of a six-week course.
-[![Econ-Teach](uctland.png)](https://github.com/jhconning/land_uct_2019)
+```{figure} uctland.png
+---
+width: 100%
+align: center
+---
+```
+[Link to Land Governance](https://github.com/jhconning/land_uct_2019)
 :::
 
 ::::

--- a/notes/newpapers.md
+++ b/notes/newpapers.md
@@ -19,7 +19,13 @@ Research
 
 :::{tab-item} Paper and Replication
 [Paper and Replication Code](https://open-enclose.github.io/)
-[![](nash_eq.png/)](https://open-enclose.github.io/)
+```{figure} nash_eq.png
+---
+width: 100%
+align: center
+---
+```
+[Link to paper](https://open-enclose.github.io/)
 :::
 
 :::{tab-item} Abstract
@@ -37,7 +43,13 @@ Research
 :::{tab-item} Paper and Replication
 [Paper and Replication Code](https://jhconning.github.io/commitments/)
 
-[![](RPconstraint.gif)](https://jhconning.github.io/commitments/)
+```{figure} RPconstraint.gif
+---
+width: 100%
+align: center
+---
+```
+[Link to paper](https://jhconning.github.io/commitments/)
 
 :::
 


### PR DESCRIPTION
Updated images in index.md, notes/Teaching.md, and notes/newpapers.md to use the `figure` directive instead of standard markdown to support custom sizing, increasing width to 100%. Replaced the inline image links with text links as requested by the user.

---
*PR created automatically by Jules for task [2577789765087177214](https://jules.google.com/task/2577789765087177214) started by @jhconning*